### PR TITLE
Add OWDeathTracker mod

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -71,5 +71,9 @@
   {
     "repo": "amazingalek/owml-enabledebugmode",
     "manifest": "manifest.json"
-  }
+  },
+  {
+    "repo": "goaaats/OWDeathTracker",
+    "manifest": "Goaaats.DeathTracker/manifest.json"
+  },
 ]

--- a/mods.json
+++ b/mods.json
@@ -75,5 +75,5 @@
   {
     "repo": "goaaats/OWDeathTracker",
     "manifest": "Goaaats.DeathTracker/manifest.json"
-  },
+  }
 ]


### PR DESCRIPTION
Adds my simple Death Tracker mod to the mod repository.

Source can be found here: https://github.com/goaaats/OWDeathTracker