### PR TITLE
Fix repo name for EotE Brighter Dreams

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -142,7 +142,7 @@
   },
   {
     "name": "EotE Brighter Dreams",
-    "uniqueName": "Heelio.EotE-Brighter-Dreams",
-    "repo": "NicholasConnors/outer-wilds-static-camera"
+    "uniqueName": "Heelio.EotEBrighterDreams",
+    "repo": "Heelio/EotE-Brighter-Dreams"
   }
 ]


### PR DESCRIPTION
Unique name also didn't match what's in their manifest.json